### PR TITLE
[feat] - Emergency msig operations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,6 @@
 ignore:
   - "lib"
   - "test"
+  - "test/BaseFixture.sol"
+  - "test/Utils.sol"
   - "src/mocks"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 ignore:
   - "lib"
   - "test"
+  - "test/BaseFixture.sol"
+  - "test/Utils.sol"
   - "src/mocks"

--- a/src/GroGovernor.sol
+++ b/src/GroGovernor.sol
@@ -190,7 +190,7 @@ contract GroGovernor is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+    ) internal override(GovernorTimelockControl, Governor) returns (uint256) {
         return super._cancel(targets, values, calldatas, descriptionHash);
     }
 

--- a/src/GroGovernor.sol
+++ b/src/GroGovernor.sol
@@ -18,6 +18,9 @@ contract GroGovernor is
     bytes32 public constant GOVERNOR_ADMIN_ROLE =
         keccak256("GOVERNOR_ADMIN_ROLE");
 
+    bytes32 public constant EMERGENCY_MSIG_ROLE =
+        keccak256("EMERGENCY_MSIG_ROLE");
+
     ///////// Storage /////////
     uint256 public votePeriod = 2 days;
     uint256 public voteDelay = 2 days;
@@ -37,12 +40,15 @@ contract GroGovernor is
 
     constructor(
         address _aggregator,
-        TimelockController _timelock
+        TimelockController _timelock,
+        address _emergencyMsig
     ) Governor("GRO Governor") GovernorTimelockControl(_timelock) {
         aggregator = IAggregator(_aggregator);
         // Allow TimelockController to change parameters
         _setRoleAdmin(GOVERNOR_ADMIN_ROLE, GOVERNOR_ADMIN_ROLE);
-        _setupRole(GOVERNOR_ADMIN_ROLE, address(_timelock));
+        _grantRole(GOVERNOR_ADMIN_ROLE, address(_timelock));
+        // Allow emergency multisig to cancel proposals
+        _grantRole(EMERGENCY_MSIG_ROLE, _emergencyMsig);
     }
 
     /// @notice Returns the delay between when a proposal is created and when voting can start
@@ -154,14 +160,29 @@ contract GroGovernor is
         return super.state(proposalId);
     }
 
+    /// @notice Proposal can be cancelled by proposer or emergency msig
+    /// @param targets The ordered list of target addresses for calls to be made
+    /// @param values The ordered list of values (i.e. msg.value)
+    /// @param calldatas The ordered list of calldata to be passed to each call
+    /// @param descriptionHash The hash of the description of the proposal
     function cancel(
         address[] memory targets,
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
     ) public override(Governor, IGovernor) returns (uint256) {
-        // TODO: Incorporate emergency MSIG ops for cancelling
-        return super.cancel(targets, values, calldatas, descriptionHash);
+        uint256 proposalId = hashProposal(
+            targets,
+            values,
+            calldatas,
+            descriptionHash
+        );
+        require(
+            _msgSender() == proposalProposer(proposalId) ||
+                hasRole(EMERGENCY_MSIG_ROLE, _msgSender()),
+            "GRO::cancel: not proposer or emergency msig"
+        );
+        return _cancel(targets, values, calldatas, descriptionHash);
     }
 
     function _cancel(

--- a/test/BaseFixture.sol
+++ b/test/BaseFixture.sol
@@ -37,7 +37,12 @@ contract BaseFixture is Test {
         // Deploy timelock controller:
         address[] memory proposers = new address[](1);
         proposers[0] = based;
-        timelock = new TimelockController(1, proposers, proposers, based);
+        timelock = new TimelockController(
+            1,
+            proposers,
+            proposers,
+            emergencyMsig
+        );
         // Mock aggregator
         aggregator = new MockVoteAggregator();
         // Create governor
@@ -48,9 +53,10 @@ contract BaseFixture is Test {
         );
 
         // Grant proposer and executoooor role to governor
-        vm.startPrank(based);
+        vm.startPrank(emergencyMsig);
         timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
         timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
         vm.stopPrank();
     }
 }

--- a/test/BaseFixture.sol
+++ b/test/BaseFixture.sol
@@ -15,6 +15,7 @@ contract BaseFixture is Test {
     address internal alice;
     address internal bob;
     address internal joe;
+    address internal emergencyMsig;
 
     GroGovernor public governor;
     MockVoteAggregator public aggregator;
@@ -22,7 +23,7 @@ contract BaseFixture is Test {
 
     function setUp() public virtual {
         utils = new Utils();
-        users = utils.createUsers(4);
+        users = utils.createUsers(5);
         based = users[0];
         vm.label(based, "BASED ADDRESS");
         alice = users[1];
@@ -31,6 +32,8 @@ contract BaseFixture is Test {
         vm.label(bob, "Bob");
         joe = users[3];
         vm.label(joe, "Joe");
+        emergencyMsig = users[4];
+        vm.label(emergencyMsig, "Emergency MSIG");
         // Deploy timelock controller:
         address[] memory proposers = new address[](1);
         proposers[0] = based;
@@ -38,7 +41,11 @@ contract BaseFixture is Test {
         // Mock aggregator
         aggregator = new MockVoteAggregator();
         // Create governor
-        governor = new GroGovernor(address(aggregator), timelock);
+        governor = new GroGovernor(
+            address(aggregator),
+            timelock,
+            emergencyMsig
+        );
 
         // Grant proposer and executoooor role to governor
         vm.startPrank(based);


### PR DESCRIPTION
## Done:
As discussed, emergency msig should be able to cancel proposals in any state(except Executed ofc)

In this PR:
- Cancel function allows to cancel to both proposer and emergency msig
- Various tests